### PR TITLE
Add missing typedef for CRef

### DIFF
--- a/src/c-ref.h
+++ b/src/c-ref.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 
+typedef _Atomic unsigned long CRef;
 typedef void (*CRefFn) (_Atomic unsigned long *ref, void *userdata);
 
 /**


### PR DESCRIPTION
The current version of `libbus1` fails to build from source with `c-sundry`
commit 8deaceba because of a missing type definition for `CRef`.

Since `c-ref.h` provides `CRefFn`, it seems logical to provide `CRef`
there as well.
