### PR TITLE
c-string: fix verify_ascii test

### DIFF
--- a/src/test-string.c
+++ b/src/test-string.c
@@ -91,15 +91,15 @@ static void test_ascii(void) {
         c_string_verify_ascii(&p, &len);
         assert(*p == 0x00);
         assert(p == str);
-        assert(len = sizeof(str));
+        assert(len == sizeof(str));
 
         ++p;
         --len;
 
         c_string_verify_ascii(&p, &len);
         assert((unsigned char)*p == 0x80);
-        assert(p = str + 0xFF);
-        assert(len  = sizeof(str) - 0xFF);
+        assert(p == str + 0x7F + 1);
+        assert(len == sizeof(str) - 0x7F - 1);
 }
 
 static void test_utf8(void) {


### PR DESCRIPTION
Use comparison, not affectation
The limit we fixed for valid ascii chars is 0x7F not 0xFF